### PR TITLE
fix: 修复组件 Carousel 不刷新 children 的问题

### DIFF
--- a/packages/Carousel/index.js
+++ b/packages/Carousel/index.js
@@ -55,8 +55,8 @@ export class Carousel extends React.PureComponent {
 
   componentWillReceiveProps(nextProps) {
 
-    // when data changes, children should be re-generated
-    if(nextProps.data !== this.props.data) {
+    // when data or children changes, children should be re-generated
+    if(nextProps.data !== this.props.data || nextProps.children !== this.props.children) {
       this.setState({children: Helper.makeChildren(nextProps)});
     }
 


### PR DESCRIPTION
问题：当子元素数量动态变化时，Carousel 组件未重新渲染。
修复：修改 componentWillReceiveProps 中重新渲染的条件判断。